### PR TITLE
fix: also adjust minimal font-size for prose content

### DIFF
--- a/src/components/kit/BaseProseSection.astro
+++ b/src/components/kit/BaseProseSection.astro
@@ -1,3 +1,3 @@
-<section class="prose max-w-prose dark:prose-invert prose-sm md:prose-base lg:prose-lg">
+<section class="prose max-w-prose dark:prose-invert prose-base lg:prose-lg">
     <slot/>
 </section>


### PR DESCRIPTION
In #35 I've forgotten to also apply this update to the tailwind typography prose-content 