### PR TITLE
chore: enable astro viewTransitions spa mode

### DIFF
--- a/src/components/kit/BaseHead.astro
+++ b/src/components/kit/BaseHead.astro
@@ -1,4 +1,6 @@
 ---
+import { ViewTransitions } from "astro:transitions";
+
 export interface Props {
   title: string;
   description: string;
@@ -21,6 +23,8 @@ const { title, description, permalink } = Astro.props;
 <title>{title}</title>
 <meta name="title" content={title} />
 <meta name="description" content={description} />
+
+<ViewTransitions />
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />


### PR DESCRIPTION
Enabling astro SPA mode using `viewTransitions` on all of the app's pages